### PR TITLE
Escape a11y-report output, to remove ANSI sequences

### DIFF
--- a/trousers/modules/a11yvalidation.py
+++ b/trousers/modules/a11yvalidation.py
@@ -1,5 +1,6 @@
 import subprocess
 import os
+import re
 
 def escape_ansi(line):
     ansi_escape = re.compile(r'(\x9B|\x1B\[)[0-?]*[ -\/]*[@-~]')

--- a/trousers/modules/a11yvalidation.py
+++ b/trousers/modules/a11yvalidation.py
@@ -1,6 +1,10 @@
 import subprocess
 import os
 
+def escape_ansi(line):
+    ansi_escape = re.compile(r'(\x9B|\x1B\[)[0-?]*[ -\/]*[@-~]')
+    return ansi_escape.sub('', line)
+
 class A11YValidation:
 
     def run(self, directories, params):
@@ -15,13 +19,14 @@ class A11YValidation:
         )
 
         out, err = ps.communicate()
+        out_escaped = escape_ansi(out)
 
         open(
             os.path.join(
                 directories.artifacts,
                 "a11y-report.txt"
             ),"w"
-        ).write(out)
+        ).write(out_escaped)
 
         return {
             "return_code": ps.returncode,


### PR DESCRIPTION
Let's see, whether the output looks better that way.