### PR TITLE
Enhance microdata module

### DIFF
--- a/trousers/data/gh_pull.mock
+++ b/trousers/data/gh_pull.mock
@@ -3,17 +3,17 @@
           "number": 2,
           "pull_request": {
             "number": 2,
-            "url": "https://api.github.com/repos/MatthewJWalls/frontend/pulls/2",
+            "url": "https://api.github.com/repos/MatthewJWalls/prbuildstub/pulls/1",
             "state": "open",
             "title": "Update the README with new information",
             "body": "This is a pretty simple change that we need to pull into master.",
-            "comments_url": "https://api.github.com/repos/MatthewJWalls/frontend/issues/2/comments",
+            "comments_url": "https://api.github.com/repos/MatthewJWalls/prbuildstub/issues/1/comments",
             "head": {
-              "label": "MatthewJWalls:anotherpatch",
-              "ref": "anotherpatch",
+              "label": "MatthewJWalls:mock",
+              "ref": "mock",
               "sha": "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
               "repo": {
-                "clone_url" : "https://github.com/MatthewJWalls/frontend.git"
+                "clone_url" : "https://github.com/MatthewJWalls/prbuildstub.git"
               }
             }
           }

--- a/trousers/modules/microdatacheck.py
+++ b/trousers/modules/microdatacheck.py
@@ -19,7 +19,7 @@ class MicroDataCheck:
 
         self.out = "microdata.txt"
 
-    def validate_microdata(self, schemadir, items):
+    def validate_microdata(self, schemadir, items, expected):
 
         """ returns a report on the given microdata items """
 
@@ -42,16 +42,24 @@ class MicroDataCheck:
             else:
                 results += "ignored %s\n" % typ
 
+        for expect in expected:
+            if expect not in results:
+                results += "invalid: page content did not contain expected microdata item '%s'\n" % expect
+
         return results
 
     def run(self, directories, params):
 
         results = ""
 
-        for url in params["urls"]:
+        for endpoint in params["endpoints"]:
+
+            url = endpoint["url"]
+            expected = endpoint["expected"]
+            
             results += "--\nresults for %s\n--\n" % url
             items = microdata.get_items(urllib.urlopen(url))
-            results += "%s\n\n" % self.validate_microdata(directories.builtins, items)
+            results += "%s\n\n" % self.validate_microdata(directories.builtins, items, expected)
 
         open(
             os.path.join(

--- a/trousers/modules/microdatacheck.py
+++ b/trousers/modules/microdatacheck.py
@@ -55,7 +55,7 @@ class MicroDataCheck:
         for endpoint in params["endpoints"]:
 
             url = endpoint["url"]
-            expected = endpoint["expected"]
+            expected = endpoint.get("expected", [])
             
             results += "--\nresults for %s\n--\n" % url
             items = microdata.get_items(urllib.urlopen(url))


### PR DESCRIPTION
The microdata module as it currently existed could only validate that microdata items that existed on the page conformed to the schema.org standards. It could *not* however check if the page was *missing* any microdata items that should be there.

This change introduces functionality to allow the microdata module to be configured to validate if microdata items are present.

old config style

```
  microdata:
    urls: 
      - http://localhost:3000/
```

new config style:

```
  microdata:
    endpoints:
      - url: http://localhost:3000/
        expected:
          - WebPage
          - LiveBloke
```

Also changed the docker integration test to pull in a simple stub repo instead of frontend, which makes the system testing loop much faster.