### PR TITLE
Introduce colored indicator for pa11y errors

### DIFF
--- a/trousers/github_comment.template
+++ b/trousers/github_comment.template
@@ -16,7 +16,7 @@ PRbuilds results:
 {% endif %}
 
 {% if "a11yvalidation" in results %}
-**A11y validation** ({{ results["a11yvalidation"]["raw_output"].count("ERROR") }})
+** {% if(int(results["a11yvalidation"]["raw_output"].count("ERROR")) == 0) '&#x1F34F;' else '&#x1F34E;' %} A11y validation** ({{ results["a11yvalidation"]["raw_output"].count("ERROR") }})
 {{ " • ".join(links_for("a11y-report")) }}
 {% endif %}
 


### PR DESCRIPTION
Prepend either a green or a red icon in front of the error count, to give a stronger visual indication, if something is wrong.