### PR TITLE
Change PRBuilds re-build behaviour

### DIFF
--- a/trousers/data/gh_comment_api_response.json
+++ b/trousers/data/gh_comment_api_response.json
@@ -5,7 +5,7 @@
     "issue_url": "https://api.github.com/repos/guardian/frontend/issues/15499",
     "id": 271269042,
     "user": {
-      "login": "MatthewJWalls",
+      "login": "PRBuilds",
       "id": 1218561,
       "avatar_url": "https://avatars2.githubusercontent.com/u/1218561?v=4",
       "gravatar_id": "",

--- a/trousers/trouserlib/github.py
+++ b/trousers/trouserlib/github.py
@@ -12,25 +12,25 @@ class GitHubService:
         self.token = token
         self.requests = requests
 
-    def has_comment(self, url, including):
+    def has_comment(self, url):
 
-        """ Is the given text included anywhere """
+        """ have we already commented on this pr """
         
         res = self.requests.get(url)
 
         res.raise_for_status()
 
         for post in res.json():
-            if including in post["body"]:
-                return True
+            if post["user"]["login"] == self.name:
+                return post
 
-        return False
+        return None
 
-    def update_comment(self, url, body, test):
+    def update_comment(self, url, body):
 
         """ Add github comment only if it doesn't exist """
 
-        if not self.has_comment(url, test):
+        if not self.has_comment(url):
             self.post_comment(url, body)
             return True
 

--- a/trousers/trouserlib/github.py
+++ b/trousers/trouserlib/github.py
@@ -28,13 +28,31 @@ class GitHubService:
 
     def update_comment(self, url, body):
 
-        """ Add github comment only if it doesn't exist """
+        """ Add or overwrite github comment """
 
-        if not self.has_comment(url):
+        existing = self.has_comment(url)
+        
+        if existing:
+            self.overwrite_comment(existing["url"], body)
+        else:
             self.post_comment(url, body)
-            return True
 
-        return False
+    def overwrite_comment(self, url, body):
+
+        """ overwrite comment on the given api url with body """
+
+	payload = { "body": body }
+        
+        res = self.requests.patch(
+            url,
+            data = json.dumps(payload),
+            auth = HTTPBasicAuth(
+                self.name,
+                self.token
+            )
+        )
+
+        res.raise_for_status()        
     
     def post_comment(self, url, body):
 

--- a/trousers/trouserlib/trousers.py
+++ b/trousers/trouserlib/trousers.py
@@ -62,7 +62,7 @@ class Trousers:
             self.github.update_comment(
                 pr.commentUrl,
                 comment,
-                "-automated message"
+                config.githubLogin
             )
 
         logging.info("PR Build %s success" % pr.prnum)

--- a/trousers/trouserlib/trousers.py
+++ b/trousers/trouserlib/trousers.py
@@ -61,8 +61,7 @@ class Trousers:
 
             self.github.update_comment(
                 pr.commentUrl,
-                comment,
-                config.githubLogin
+                comment
             )
 
         logging.info("PR Build %s success" % pr.prnum)

--- a/trousers/trousers_test.py
+++ b/trousers/trousers_test.py
@@ -31,7 +31,11 @@ class MockRequests:
     def get(self, url):
         self.lastUrl = url
         self.lastData = None
-        return self.response        
+        return self.response
+    def patch(self, url, data, auth):
+        self.lastUrl = url
+        self.lastData = data
+        return self.response
 
 class MockBucket:
     def upload_file(self, source, dest, ExtraArgs):
@@ -82,11 +86,14 @@ class GitHubServiceTests(unittest.TestCase):
             MockResponse(200, open("data/gh_comment_api_response.json").read())
         )
         
-        self.assertFalse(
-            s.update_comment(
-                "https://api.github.com/repos/guardian/frontend/issues/15499/comments",
-                "This is the body"
-            )
+        s.update_comment(
+            "https://api.github.com/repos/guardian/frontend/issues/15499/comments",
+            "This is the body"
+        )
+
+        self.assertEqual(
+            s.requests.lastUrl,
+            "https://api.github.com/repos/guardian/frontend/issues/comments/271269042"
         )
 
     def test_update_comment_when_none_exist(self):
@@ -96,13 +103,10 @@ class GitHubServiceTests(unittest.TestCase):
             MockResponse(200, open("data/gh_comment_api_response.json").read())
         )
         
-        self.assertTrue(
-            s.update_comment(
-                "https://api.github.com/repos/guardian/frontend/issues/15499/comments",
-                "This is the body"
-            )
-        )        
-        
+        s.update_comment(
+            "https://api.github.com/repos/guardian/frontend/issues/15499/comments",
+            "This is the body"
+        )
 
 class PullRequestTests(unittest.TestCase):
 

--- a/trousers/trousers_test.py
+++ b/trousers/trousers_test.py
@@ -44,7 +44,7 @@ class GitHubServiceTests(unittest.TestCase):
     """ does not talk to the real github """
     
     def test_post_comment(self):
-        s = GitHubService("name", "token")
+        s = GitHubService("PRBuilds", "token")
         r = MockRequests()
         s.requests = r
         s.post_comment("url", "payload")
@@ -52,30 +52,57 @@ class GitHubServiceTests(unittest.TestCase):
         self.assertTrue("payload" in r.lastData)
 
     def test_has_comment(self):
-        s = GitHubService("name", "token")
+        s = GitHubService("PRBuilds", "token")
         s.requests = MockRequests(
             MockResponse(200, open("data/gh_comment_api_response.json").read())
         )
         
         self.assertTrue(
             s.has_comment(
-                "https://api.github.com/repos/guardian/frontend/issues/15499/comments",
-                "PR build"
-            )
+                "https://api.github.com/repos/guardian/frontend/issues/15499/comments"
+            ) != None
         )
 
     def test_has_no_comment(self):
-        s = GitHubService("name", "token")
+        s = GitHubService("Wooooow", "token")
+        s.requests = MockRequests(
+            MockResponse(200, open("data/gh_comment_api_response.json").read())
+        )
+        
+        self.assertTrue(
+            s.has_comment(
+                "https://api.github.com/repos/guardian/frontend/issues/15499/comments"
+            ) == None
+        )
+
+    def test_update_comment_when_one_exists(self):
+        
+        s = GitHubService("PRBuilds", "token")
         s.requests = MockRequests(
             MockResponse(200, open("data/gh_comment_api_response.json").read())
         )
         
         self.assertFalse(
-            s.has_comment(
+            s.update_comment(
                 "https://api.github.com/repos/guardian/frontend/issues/15499/comments",
-                "WoooWooooowoowoww"
+                "This is the body"
             )
         )
+
+    def test_update_comment_when_none_exist(self):
+        
+        s = GitHubService("Wooooow", "token")
+        s.requests = MockRequests(
+            MockResponse(200, open("data/gh_comment_api_response.json").read())
+        )
+        
+        self.assertTrue(
+            s.update_comment(
+                "https://api.github.com/repos/guardian/frontend/issues/15499/comments",
+                "This is the body"
+            )
+        )        
+        
 
 class PullRequestTests(unittest.TestCase):
 
@@ -84,9 +111,9 @@ class PullRequestTests(unittest.TestCase):
     def test_fields(self):
         mock = open("data/gh_pull.mock").read()
         pull = PullRequest(mock)
-        self.assertEqual(pull.branch, "anotherpatch")
-        self.assertTrue("frontend" in pull.cloneUrl)
-        self.assertTrue("frontend" in pull.commentUrl)
+        self.assertEqual(pull.branch, "mock")
+        self.assertTrue("prbuildstub" in pull.cloneUrl)
+        self.assertTrue("prbuildstub" in pull.commentUrl)
         self.assertEqual(pull.prnum, 2)
 
         


### PR DESCRIPTION

Change the behaviour of prbuilds wrt how it handles rebuilding the same PR.

This is a three step refactor

1. change prbuilds's comment update logic to look for it's own username, not the "automated message" tag **(under this PR)**
2. change prbuilds to update it's existing comment when it rebuilds the PR **(under this PR)**
3.  let people manually fire off prbuilds again (under a future PR) - slightly more involved

@gustavpursche 
