### PR TITLE
Reduce instance size to t2.medium

### DIFF
--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -150,7 +150,7 @@ Resources:
     Type: 'AWS::AutoScaling::LaunchConfiguration'
     Properties:
       ImageId: !Ref AMIParameter
-      InstanceType: c4.large
+      InstanceType: t2.medium
       AssociatePublicIpAddress: true
       IamInstanceProfile: !Ref InstanceProfileParameter
       KeyName: !Ref KeyNameParameter


### PR DESCRIPTION
I'm just reviewing AWS costs and noticed that we haven't reserved the instance PRBuilds runs on. I had a look at the CPU usage, and it looks quite spiky:

<img width="877" alt="screen shot 2018-07-20 at 15 55 51" src="https://user-images.githubusercontent.com/3606555/43009413-88349c78-8c35-11e8-866d-b967feedd9c1.png">

Which could be a good use case for the t2 instance class - as it only needs lots of CPU when someone makes a PR. t2.medium has the [same amount of memory as a c5.large](https://www.ec2instances.info/?region=eu-west-1&cost_duration=annually&selected=t2.small,t2.medium,t2.large,c5.large,c5.2xlarge) but only 5h/day of full CPU usage.

If this has been tried before and won't work then we should at least change it to a c5.large.